### PR TITLE
fix: register app event or app runner not working

### DIFF
--- a/spring/spring-core/gs/app.go
+++ b/spring/spring-core/gs/app.go
@@ -140,6 +140,7 @@ func (app *App) start() error {
 
 	app.Object(app.router)
 	app.Object(app.consumers)
+	app.Object(app)
 
 	e := &environment{p: conf.New()}
 	if err := e.prepare(); err != nil {


### PR DESCRIPTION
由于没有对 app 进行注入导致 appevent 无法识别