### PR TITLE
fix: empty string misconsidered as undefined

### DIFF
--- a/spring/spring-core/conf/bind.go
+++ b/spring/spring-core/conf/bind.go
@@ -373,6 +373,9 @@ func resolveString(p *Properties, s string) (string, error) {
 func resolve(p *Properties, param BindParam) (string, error) {
 	val := p.Get(param.Key)
 	if val == "" {
+		if p.Has(param.Key) {
+			return "", nil
+		}
 		if param.hasDef {
 			val = param.def
 		} else {


### PR DESCRIPTION
用户配置的空字符串也应该可以获取到